### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Valhalla
 [![Build Status](https://travis-ci.org/petermelias/valhalla.png?branch=master)](https://travis-ci.org/petermelias/valhalla) 
 [![Coverage Status](https://coveralls.io/repos/petermelias/valhalla/badge.png?branch=master)](https://coveralls.io/r/petermelias/valhalla?branch=master) 
-[![Downloads](https://pypip.in/d/valhalla/badge.png)](https://pypi.python.org/pypi/valhalla/) 
-[![Downloads](https://pypip.in/v/valhalla/badge.png)](https://pypi.python.org/pypi/valhalla/)
+[![Downloads](https://img.shields.io/pypi/dm/valhalla.svg)](https://pypi.python.org/pypi/valhalla/) 
+[![Downloads](https://img.shields.io/pypi/v/valhalla.svg)](https://pypi.python.org/pypi/valhalla/)
 
 The API is designed to afford the programmer the least amount of typing for each
 use case, with the option to be more verbose when necessary.


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20valhalla))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `valhalla`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.

Unfortunately, [PyPI has removed download statistics from their API](https://mail.python.org/pipermail/distutils-sig/2013-May/020855.html), which means that even the shields.io "download count" badges are broken (they display "no longer available". See [this](https://github.com/badges/shields/issues/716)). So those badges should really be removed entirely. Since this is an automated process (and trying to automatically remove the badges from READMEs can be tricky), this pull request just replaces the URL with the shields.io syntax.